### PR TITLE
Fix #1 : Dependency updates to build with Java-9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,13 +18,14 @@
     <jdkLevel>1.8</jdkLevel>
 
     <bval.version>0.5</bval.version>
+    <commons-lang.version>3.6</commons-lang.version>
     <fest.version>2.0M10</fest.version>
     <guava.version>17.0</guava.version>
-    <jackson2.version>2.8.7</jackson2.version>
+    <jackson2.version>2.8.9</jackson2.version>
     <jcommander.version>1.60</jcommander.version>
     <junit.version>4.12</junit.version>
     <logback.version>1.2.3</logback.version>
-    <mockito.version>1.9.5</mockito.version>
+    <mockito.version>2.8.9</mockito.version>
     <slf4j.version>1.7.25</slf4j.version>
     <validation-api.version>1.1.0.Final</validation-api.version>
   </properties>
@@ -58,6 +59,11 @@
       <groupId>com.beust</groupId>
       <artifactId>jcommander</artifactId>
       <version>${jcommander.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>${commons-lang.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>


### PR DESCRIPTION
Minor dependency updates to build with Java-9.

In particular, commons-lang3 was a transitive dependency through bval-jsr303, but needed to be updated to work with the new JVM version scheme, because "1.8" has been succeeded by "9", causing the version string parser in commons-lang3:3.1 to break.

I also attempted to update jcommander as a test, but that caused issues, so it has been left as it is and filed as issue #2